### PR TITLE
refactor: replace header parser classes with plain objects

### DIFF
--- a/src/galactic/__tests__/__snapshots__/parse.test.ts.snap
+++ b/src/galactic/__tests__/__snapshots__/parse.test.ts.snap
@@ -37,7 +37,7 @@ SUBFILE18 = 5/3/1995, 9:29:44, "18        "
 SUBFILE19 = 5/3/1995, 9:29:44, "19        " 
 SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
   },
-  "meta": TheNewHeader {
+  "meta": {
     "calibrationLevel": 0,
     "concentrationFactor": 0,
     "date": "0000-00-00T00:00:00.00Z",
@@ -45,12 +45,13 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
     "experimentType": "General SPC (could be anything)",
     "exponentY": 4,
     "fileVersion": 75,
+    "kind": "new",
     "logOffset": 57152,
     "memo": "NIR Spectra Example",
     "methodFile": "",
     "modifiedFlag": 0,
     "numberPoints": 700,
-    "parameters": FlagParameters {
+    "parameters": {
       "customAxisLabels": false,
       "multiFile": true,
       "useExperimentExtension": false,
@@ -90,14 +91,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
   },
   "spectra": [
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 1,
         "exponentY": 4,
         "indexNumber": 0,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -1526,14 +1527,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 2,
         "exponentY": -128,
         "indexNumber": 1,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -2962,14 +2963,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 3,
         "exponentY": -128,
         "indexNumber": 2,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -4398,14 +4399,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 4,
         "exponentY": -128,
         "indexNumber": 3,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -5834,14 +5835,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 5,
         "exponentY": -128,
         "indexNumber": 4,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -7270,14 +7271,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 6,
         "exponentY": -128,
         "indexNumber": 5,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -8706,14 +8707,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 7,
         "exponentY": -128,
         "indexNumber": 6,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -10142,14 +10143,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 8,
         "exponentY": -128,
         "indexNumber": 7,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -11578,14 +11579,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 9,
         "exponentY": -128,
         "indexNumber": 8,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -13014,14 +13015,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 10,
         "exponentY": -128,
         "indexNumber": 9,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -14450,14 +14451,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 11,
         "exponentY": -128,
         "indexNumber": 10,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -15886,14 +15887,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 12,
         "exponentY": -128,
         "indexNumber": 11,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -17322,14 +17323,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 13,
         "exponentY": -128,
         "indexNumber": 12,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -18758,14 +18759,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 14,
         "exponentY": -128,
         "indexNumber": 13,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -20194,14 +20195,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 15,
         "exponentY": -128,
         "indexNumber": 14,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -21630,14 +21631,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 16,
         "exponentY": -128,
         "indexNumber": 15,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -23066,14 +23067,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 17,
         "exponentY": -128,
         "indexNumber": 16,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -24502,14 +24503,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 18,
         "exponentY": -128,
         "indexNumber": 17,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -25938,14 +25939,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 19,
         "exponentY": -128,
         "indexNumber": 18,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,
@@ -27374,14 +27375,14 @@ SUBFILE20 = 5/3/1995, 9:29:44, "20        "",
       },
     },
     {
-      "meta": SubHeader {
+      "meta": {
         "endingZ": 20,
         "exponentY": -128,
         "indexNumber": 19,
         "noiseValue": 0,
         "numberCoAddedScans": 4,
         "numberPoints": 0,
-        "parameters": SubFlagParameters {
+        "parameters": {
           "changed": false,
           "modifiedArithmetic": false,
           "noPeakTable": false,

--- a/src/galactic/__tests__/parse.test.ts
+++ b/src/galactic/__tests__/parse.test.ts
@@ -49,7 +49,7 @@ describe('parse', () => {
       isDependent: false,
     });
     expect(result.spectra).toHaveLength(1);
-    expect(Object.keys(result.meta)).toHaveLength(31);
+    expect(Object.keys(result.meta)).toHaveLength(32);
   });
 
   it('raman-sion.spc', () => {
@@ -65,7 +65,7 @@ describe('parse', () => {
       isDependent: false,
     });
     expect(result.spectra).toHaveLength(36);
-    expect(Object.keys(result.meta)).toHaveLength(31);
+    expect(Object.keys(result.meta)).toHaveLength(32);
 
     const dataY = result.spectra[0].variables.y.data;
 

--- a/src/galactic/dataBlock/newDataBlock.ts
+++ b/src/galactic/dataBlock/newDataBlock.ts
@@ -5,7 +5,8 @@ import { createFromToArray } from 'ml-spectra-processing';
 import type { TheNewHeader } from '../fileHeader.ts';
 import { getDataShape } from '../utility/getDataShape.ts';
 
-import { SubHeader, setXYAxis } from './shared.ts';
+import type { SubHeader } from './shared.ts';
+import { parseSubHeader, setXYAxis } from './shared.ts';
 
 /**
  * Reads the data block of the SPC file.
@@ -39,7 +40,7 @@ export function newDataBlock(
 
   for (let i = 0; i < fileHeader.spectra; i++) {
     // here Y is set (runs only once for a single spectra.)
-    const subFileHeader = new SubHeader(buffer);
+    const subFileHeader = parseSubHeader(buffer);
 
     // set X for the remaining cases if neccesary
     if (dataShape === 'XYXY' || dataShape === 'exception') {

--- a/src/galactic/dataBlock/oldDataBlock.ts
+++ b/src/galactic/dataBlock/oldDataBlock.ts
@@ -4,7 +4,8 @@ import { createFromToArray } from 'ml-spectra-processing';
 
 import type { TheOldHeader } from '../fileHeader.ts';
 
-import { SubHeader, setXYAxis } from './shared.ts';
+import type { SubHeader } from './shared.ts';
+import { parseSubHeader, setXYAxis } from './shared.ts';
 
 /**
  * Reads a file's data block (old SPC format)
@@ -31,7 +32,7 @@ export function oldDataBlock(
     buffer.offset + fileHeader.numberPoints < buffer.length;
     i++
   ) {
-    const subFileHeader = new SubHeader(buffer);
+    const subFileHeader = parseSubHeader(buffer);
     const y = getOldY(
       new Float64Array(x.length),
       subFileHeader,

--- a/src/galactic/dataBlock/shared.ts
+++ b/src/galactic/dataBlock/shared.ts
@@ -4,52 +4,58 @@ import { xySortX } from 'ml-spectra-processing';
 
 import type { Header } from '../fileHeader.ts';
 
-/**
- * Gets the Subfile flags.
- * @param  flag - First byte of the subheader.
- * @returns The parameters.
- */
-export class SubFlagParameters {
-  public changed: boolean;
-  public noPeakTable: boolean;
-  public modifiedArithmetic: boolean;
-  constructor(flag: number) {
-    this.changed = (flag & 1) !== 0;
-    this.noPeakTable = (flag & 8) !== 0;
-    this.modifiedArithmetic = (flag & 128) !== 0;
-  }
+/** The flags encoded in the first byte of the subheader. */
+export interface SubFlagParameters {
+  changed: boolean;
+  noPeakTable: boolean;
+  modifiedArithmetic: boolean;
 }
 
 /**
- * Parses the subheader (header of the subfile)
- * @param buffer - SPC buffer.
- * @returns subheader object
+ * Gets the Subfile flags.
+ * @param flag - First byte of the subheader.
+ * @returns The parameters.
  */
-export class SubHeader {
-  //all formats have the same subheader
-  public parameters: SubFlagParameters;
-  public exponentY: number;
-  public indexNumber: number;
-  public startingZ: number;
-  public endingZ: number;
-  public noiseValue: number;
-  public numberPoints: number;
-  public numberCoAddedScans: number;
-  public wAxisValue: number;
-  public reserved: string;
+export function parseSubFlagParameters(flag: number): SubFlagParameters {
+  return {
+    changed: (flag & 1) !== 0,
+    noPeakTable: (flag & 8) !== 0,
+    modifiedArithmetic: (flag & 128) !== 0,
+  };
+}
 
-  constructor(buffer: IOBuffer) {
-    this.parameters = new SubFlagParameters(buffer.readUint8());
-    this.exponentY = buffer.readInt8();
-    this.indexNumber = buffer.readUint16();
-    this.startingZ = buffer.readFloat32();
-    this.endingZ = buffer.readFloat32();
-    this.noiseValue = buffer.readFloat32();
-    this.numberPoints = buffer.readUint32();
-    this.numberCoAddedScans = buffer.readUint32();
-    this.wAxisValue = buffer.readFloat32();
-    this.reserved = buffer.readChars(4).replaceAll('\u0000', '').trim();
-  }
+/** The subheader (header of the subfile). All formats share the same subheader. */
+export interface SubHeader {
+  parameters: SubFlagParameters;
+  exponentY: number;
+  indexNumber: number;
+  startingZ: number;
+  endingZ: number;
+  noiseValue: number;
+  numberPoints: number;
+  numberCoAddedScans: number;
+  wAxisValue: number;
+  reserved: string;
+}
+
+/**
+ * Parses the subheader (header of the subfile).
+ * @param buffer - SPC buffer.
+ * @returns subheader object.
+ */
+export function parseSubHeader(buffer: IOBuffer): SubHeader {
+  return {
+    parameters: parseSubFlagParameters(buffer.readUint8()),
+    exponentY: buffer.readInt8(),
+    indexNumber: buffer.readUint16(),
+    startingZ: buffer.readFloat32(),
+    endingZ: buffer.readFloat32(),
+    noiseValue: buffer.readFloat32(),
+    numberPoints: buffer.readUint32(),
+    numberCoAddedScans: buffer.readUint32(),
+    wAxisValue: buffer.readFloat32(),
+    reserved: buffer.readChars(4).replaceAll('\u0000', '').trim(),
+  };
 }
 
 /**

--- a/src/galactic/fileHeader.ts
+++ b/src/galactic/fileHeader.ts
@@ -1,170 +1,224 @@
 import type { IOBuffer } from 'iobuffer';
 
 import { experimentSettings, xzwTypes, yTypes } from './types.ts';
-import { FlagParameters, longToDate } from './utility/headerUtils.ts';
+import type { FlagParameters } from './utility/headerUtils.ts';
+import { longToDate, parseFlagParameters } from './utility/headerUtils.ts';
 
-/**
- * Old-format File-header parsing.
- * @param buffer - spc buffer.
- * @param  prev - `{parameters,fileversion}`
- * @returns  file metadata
- */
-export class TheOldHeader {
-  public fileVersion: number;
-  public parameters: FlagParameters;
-  public exponentY: number;
-  public numberPoints: number;
-  public startingX: number;
-  public endingX: number;
-  public xUnitsType: string | number;
-  public yUnitsType: string;
-  public date: string;
-  public resolutionDescription: string;
-  public peakPointNumber: number;
-  public scans: number;
-  public spare: number[];
-  public memo: string;
-  public xyzLabels: string;
-  constructor(
-    buffer: IOBuffer,
-    prev: { parameters: FlagParameters; fileVersion: number },
-  ) {
-    this.fileVersion = prev.fileVersion; //Each bit contains a parameter
-    this.parameters = prev.parameters; //4B => New format; 4D => LabCalc format
-    this.exponentY = buffer.readInt16(); //Word (16 bits) instead of byte
-    this.numberPoints = buffer.readFloat32();
-    this.startingX = buffer.readFloat32();
-    this.endingX = buffer.readFloat32();
-    this.xUnitsType = xzwTypes(buffer.readUint8());
-    this.yUnitsType = yTypes(buffer.readUint8());
-    const date = new Date();
-    const zTypeYear = buffer.readUint16(); //Unrelated to Z axis
-    date.setUTCFullYear(zTypeYear % 4096); // TODO: might be wrong
-    date.setUTCMonth(Math.max(buffer.readUint8() - 1, 0));
-    date.setUTCDate(buffer.readUint8());
-    date.setUTCHours(buffer.readUint8());
-    date.setUTCMinutes(buffer.readUint8());
-    this.date = date.toISOString();
-    this.resolutionDescription = buffer
-      .readChars(8)
-      .replaceAll('\u0000', '')
-      .trim();
-    this.peakPointNumber = buffer.readUint16();
-    this.scans = buffer.readUint16();
-    this.spare = [];
-    for (let i = 0; i < 7; i++) {
-      this.spare.push(buffer.readFloat32());
-    }
-    this.memo = buffer.readChars(130).replaceAll('\u0000', '').trim();
-    this.xyzLabels = buffer.readChars(30).replaceAll('\u0000', '').trim();
-  }
+interface HeaderOptions {
+  parameters: FlagParameters;
+  fileVersion: number;
 }
 
-/**
- * New format file-header parsing.
- * @param buffer - spc buffer.
- * @param  prev - `{parameters,fileversion}`
- * @returns  file metadata
- */
-export class TheNewHeader {
-  public fileVersion: number;
-  public parameters: FlagParameters;
-  public experimentType: string;
-  public exponentY: number;
-  public numberPoints: number;
-  public startingX: number;
-  public endingX: number;
-  public spectra: number;
-  public xUnitsType: string | number;
-  public yUnitsType: string;
-  public zUnitsType: string | number;
-  public postingDisposition: number;
-  public date: string;
-  public resolutionDescription: string;
-  public sourceInstrumentDescription: string;
-  public peakPointNumber: number;
-  public spare: number[];
-  public memo: string;
-  public xyzLabels: string;
-  public logOffset: number;
-  public modifiedFlag: number;
-  public processingCode: number;
-  public calibrationLevel: number;
-  public subMethodSampleInjectionNumber: number;
-  public concentrationFactor: number;
-  public methodFile: string;
-  public zSubIncrement: number;
-  public wPlanes: number;
-  public wPlaneIncrement: number;
-  public wAxisUnits: string | number;
-  public reserved: string;
+/** Old-format (LabCalc) file header. */
+export interface TheOldHeader {
+  kind: 'old';
+  fileVersion: number;
+  parameters: FlagParameters;
+  exponentY: number;
+  numberPoints: number;
+  startingX: number;
+  endingX: number;
+  xUnitsType: string | number;
+  yUnitsType: string;
+  date: string;
+  resolutionDescription: string;
+  peakPointNumber: number;
+  scans: number;
+  spare: number[];
+  memo: string;
+  xyzLabels: string;
+}
 
-  constructor(
-    buffer: IOBuffer,
-    prev: { parameters: FlagParameters; fileVersion: number },
-  ) {
-    this.fileVersion = prev.fileVersion; //Each bit contains a parameter
-    this.parameters = prev.parameters; //4B => New format; 4D => LabCalc format
-    this.experimentType = experimentSettings(buffer.readUint8()); //Experiment type code (See SPC.h)
-    this.exponentY = buffer.readInt8(); //Exponent for Y values (80h = floating point): FloatY = (2^Exp)*IntY/(2^32) 32-bit; FloatY = (2^Exp)*IntY/(2^16) 32-bit
-    this.numberPoints = buffer.readUint32(); //Number of points (if not XYXY)
-    this.startingX = buffer.readFloat64(); //First X coordinate
-    this.endingX = buffer.readFloat64(); //Last X coordinate
-    this.spectra = buffer.readUint32(); //Number of spectrums
-    this.xUnitsType = xzwTypes(buffer.readUint8()); //X Units type code (See types.js)
-    this.yUnitsType = yTypes(buffer.readUint8()); //Y ""
-    this.zUnitsType = xzwTypes(buffer.readUint8()); //Z ""
-    this.postingDisposition = buffer.readUint8(); //Posting disposition (See GRAMSDDE.H)
-    this.date = longToDate(buffer.readUint32()); //Date: minutes = first 6 bits, hours = 5 next bits, days = 5 next, months = 4 next, years = 12 last
-    this.resolutionDescription = buffer
-      .readChars(9)
-      .replaceAll('\u0000', '')
-      .trim(); //Resolution description text
-    this.sourceInstrumentDescription = buffer
-      .readChars(9)
-      .replaceAll('\u0000', '')
-      .trim(); // Source Instrument description text
-    this.peakPointNumber = buffer.readUint16(); //Peak point number for interferograms
-    this.spare = [];
-    for (let i = 0; i < 8; i++) {
-      this.spare.push(buffer.readFloat32());
-    }
-    if (this.fileVersion === 0x4c) {
-      //Untested case because no test files
-      this.spare = this.spare.toReversed();
-    }
-    this.memo = buffer.readChars(130).replaceAll('\u0000', '').trim();
-    this.xyzLabels = buffer.readChars(30).replaceAll('\u0000', '').trim();
-    this.logOffset = buffer.readUint32(); //Byte offset to Log Block
-    this.modifiedFlag = buffer.readUint32(); //File modification flag (See values in SPC.H)
-    this.processingCode = buffer.readUint8(); //Processing code (See GRAMSDDE.H)
-    this.calibrationLevel = buffer.readUint8(); //Calibration level + 1
-    this.subMethodSampleInjectionNumber = buffer.readUint16(); //Sub-method sample injection number
-    this.concentrationFactor = buffer.readFloat32(); //Floating data multiplier concentration factor
-    this.methodFile = buffer.readChars(48).replaceAll('\u0000', '').trim(); //Method file
-    this.zSubIncrement = buffer.readFloat32(); //Z subfile increment for even Z Multifiles
-    this.wPlanes = buffer.readUint32();
-    this.wPlaneIncrement = buffer.readFloat32();
-    this.wAxisUnits = xzwTypes(buffer.readUint8()); //W axis units code
-    this.reserved = buffer.readChars(187).replaceAll('\u0000', '').trim(); //Reserved space (Must be zero)
-    if (this.xUnitsType === 0) {
-      this.xUnitsType = this.xyzLabels.slice(0, 10);
-    }
-    if (this.zUnitsType === 0) {
-      this.zUnitsType = this.xyzLabels.slice(20, 30);
-    }
-  }
+/** New-format file header. */
+export interface TheNewHeader {
+  kind: 'new';
+  fileVersion: number;
+  parameters: FlagParameters;
+  experimentType: string;
+  exponentY: number;
+  numberPoints: number;
+  startingX: number;
+  endingX: number;
+  spectra: number;
+  xUnitsType: string | number;
+  yUnitsType: string;
+  zUnitsType: string | number;
+  postingDisposition: number;
+  date: string;
+  resolutionDescription: string;
+  sourceInstrumentDescription: string;
+  peakPointNumber: number;
+  spare: number[];
+  memo: string;
+  xyzLabels: string;
+  logOffset: number;
+  modifiedFlag: number;
+  processingCode: number;
+  calibrationLevel: number;
+  subMethodSampleInjectionNumber: number;
+  concentrationFactor: number;
+  methodFile: string;
+  zSubIncrement: number;
+  wPlanes: number;
+  wPlaneIncrement: number;
+  wAxisUnits: string | number;
+  reserved: string;
 }
 
 export type Header = TheOldHeader | TheNewHeader;
 
 /**
+ * Old-format File-header parsing.
+ * @param buffer - spc buffer.
+ * @param prev - `{parameters, fileVersion}`.
+ * @returns file metadata.
+ */
+function parseOldHeader(buffer: IOBuffer, prev: HeaderOptions): TheOldHeader {
+  const exponentY = buffer.readInt16(); //Word (16 bits) instead of byte
+  const numberPoints = buffer.readFloat32();
+  const startingX = buffer.readFloat32();
+  const endingX = buffer.readFloat32();
+  const xUnitsType = xzwTypes(buffer.readUint8());
+  const yUnitsType = yTypes(buffer.readUint8());
+  const date = new Date();
+  const zTypeYear = buffer.readUint16(); //Unrelated to Z axis
+  date.setUTCFullYear(zTypeYear % 4096); // TODO: might be wrong
+  date.setUTCMonth(Math.max(buffer.readUint8() - 1, 0));
+  date.setUTCDate(buffer.readUint8());
+  date.setUTCHours(buffer.readUint8());
+  date.setUTCMinutes(buffer.readUint8());
+  const resolutionDescription = buffer
+    .readChars(8)
+    .replaceAll('\u0000', '')
+    .trim();
+  const peakPointNumber = buffer.readUint16();
+  const scans = buffer.readUint16();
+  const spare: number[] = [];
+  for (let i = 0; i < 7; i++) {
+    spare.push(buffer.readFloat32());
+  }
+  const memo = buffer.readChars(130).replaceAll('\u0000', '').trim();
+  const xyzLabels = buffer.readChars(30).replaceAll('\u0000', '').trim();
+
+  return {
+    kind: 'old',
+    fileVersion: prev.fileVersion, //Each bit contains a parameter
+    parameters: prev.parameters, //4B => New format; 4D => LabCalc format
+    exponentY,
+    numberPoints,
+    startingX,
+    endingX,
+    xUnitsType,
+    yUnitsType,
+    date: date.toISOString(),
+    resolutionDescription,
+    peakPointNumber,
+    scans,
+    spare,
+    memo,
+    xyzLabels,
+  };
+}
+
+/**
+ * New format file-header parsing.
+ * @param buffer - spc buffer.
+ * @param prev - `{parameters, fileVersion}`.
+ * @returns file metadata.
+ */
+function parseNewHeader(buffer: IOBuffer, prev: HeaderOptions): TheNewHeader {
+  const experimentType = experimentSettings(buffer.readUint8()); //Experiment type code (See SPC.h)
+  const exponentY = buffer.readInt8(); //Exponent for Y values (80h = floating point): FloatY = (2^Exp)*IntY/(2^32) 32-bit; FloatY = (2^Exp)*IntY/(2^16) 32-bit
+  const numberPoints = buffer.readUint32(); //Number of points (if not XYXY)
+  const startingX = buffer.readFloat64(); //First X coordinate
+  const endingX = buffer.readFloat64(); //Last X coordinate
+  const spectra = buffer.readUint32(); //Number of spectrums
+  let xUnitsType: string | number = xzwTypes(buffer.readUint8()); //X Units type code (See types.js)
+  const yUnitsType = yTypes(buffer.readUint8()); //Y ""
+  let zUnitsType: string | number = xzwTypes(buffer.readUint8()); //Z ""
+  const postingDisposition = buffer.readUint8(); //Posting disposition (See GRAMSDDE.H)
+  const date = longToDate(buffer.readUint32()); //Date: minutes = first 6 bits, hours = 5 next bits, days = 5 next, months = 4 next, years = 12 last
+  const resolutionDescription = buffer
+    .readChars(9)
+    .replaceAll('\u0000', '')
+    .trim(); //Resolution description text
+  const sourceInstrumentDescription = buffer
+    .readChars(9)
+    .replaceAll('\u0000', '')
+    .trim(); // Source Instrument description text
+  const peakPointNumber = buffer.readUint16(); //Peak point number for interferograms
+  let spare: number[] = [];
+  for (let i = 0; i < 8; i++) {
+    spare.push(buffer.readFloat32());
+  }
+  if (prev.fileVersion === 0x4c) {
+    //Untested case because no test files
+    spare = spare.toReversed();
+  }
+  const memo = buffer.readChars(130).replaceAll('\u0000', '').trim();
+  const xyzLabels = buffer.readChars(30).replaceAll('\u0000', '').trim();
+  const logOffset = buffer.readUint32(); //Byte offset to Log Block
+  const modifiedFlag = buffer.readUint32(); //File modification flag (See values in SPC.H)
+  const processingCode = buffer.readUint8(); //Processing code (See GRAMSDDE.H)
+  const calibrationLevel = buffer.readUint8(); //Calibration level + 1
+  const subMethodSampleInjectionNumber = buffer.readUint16(); //Sub-method sample injection number
+  const concentrationFactor = buffer.readFloat32(); //Floating data multiplier concentration factor
+  const methodFile = buffer.readChars(48).replaceAll('\u0000', '').trim(); //Method file
+  const zSubIncrement = buffer.readFloat32(); //Z subfile increment for even Z Multifiles
+  const wPlanes = buffer.readUint32();
+  const wPlaneIncrement = buffer.readFloat32();
+  const wAxisUnits = xzwTypes(buffer.readUint8()); //W axis units code
+  const reserved = buffer.readChars(187).replaceAll('\u0000', '').trim(); //Reserved space (Must be zero)
+  if (xUnitsType === 0) {
+    xUnitsType = xyzLabels.slice(0, 10);
+  }
+  if (zUnitsType === 0) {
+    zUnitsType = xyzLabels.slice(20, 30);
+  }
+
+  return {
+    kind: 'new',
+    fileVersion: prev.fileVersion, //Each bit contains a parameter
+    parameters: prev.parameters, //4B => New format; 4D => LabCalc format
+    experimentType,
+    exponentY,
+    numberPoints,
+    startingX,
+    endingX,
+    spectra,
+    xUnitsType,
+    yUnitsType,
+    zUnitsType,
+    postingDisposition,
+    date,
+    resolutionDescription,
+    sourceInstrumentDescription,
+    peakPointNumber,
+    spare,
+    memo,
+    xyzLabels,
+    logOffset,
+    modifiedFlag,
+    processingCode,
+    calibrationLevel,
+    subMethodSampleInjectionNumber,
+    concentrationFactor,
+    methodFile,
+    zSubIncrement,
+    wPlanes,
+    wPlaneIncrement,
+    wAxisUnits,
+    reserved,
+  };
+}
+
+/**
  * File-header parsing - First 512/256 bytes (new/old format).
  * @param buffer - SPC buffer.
- * @returns File-header object
+ * @returns File-header object.
  */
 export function fileHeader(buffer: IOBuffer): Header {
-  const parameters = new FlagParameters(buffer.readUint8()); //Each bit contains a parameter
+  const parameters = parseFlagParameters(buffer.readUint8()); //Each bit contains a parameter
   const fileVersion = buffer.readUint8(); //4B => New format; 4D => LabCalc format
   const headerOpts = { parameters, fileVersion };
 
@@ -176,12 +230,12 @@ export function fileHeader(buffer: IOBuffer): Header {
       break;
     case 0x4d: {
       // old LabCalc format
-      return new TheOldHeader(buffer, headerOpts);
+      return parseOldHeader(buffer, headerOpts);
     }
     default:
       throw new Error(
         'Unrecognized file format: byte 01 must be either 4B, 4C or 4D',
       );
   }
-  return new TheNewHeader(buffer, headerOpts);
+  return parseNewHeader(buffer, headerOpts);
 }

--- a/src/galactic/parse.ts
+++ b/src/galactic/parse.ts
@@ -4,7 +4,7 @@ import type { IOBuffer } from 'iobuffer';
 import { newDataBlock } from './dataBlock/newDataBlock.ts';
 import { oldDataBlock } from './dataBlock/oldDataBlock.ts';
 import type { Header } from './fileHeader.ts';
-import { TheNewHeader, fileHeader } from './fileHeader.ts';
+import { fileHeader } from './fileHeader.ts';
 import type { LogBlock } from './logBlock.ts';
 import { readLogBlock } from './logBlock.ts';
 
@@ -22,7 +22,7 @@ export interface GalacticParseResult {
 export function parseGalactic(ioBuffer: IOBuffer): GalacticParseResult {
   const meta = fileHeader(ioBuffer);
 
-  if (meta instanceof TheNewHeader) {
+  if (meta.kind === 'new') {
     const spectra = newDataBlock(ioBuffer, meta);
     const logs =
       meta.logOffset !== 0 ? readLogBlock(ioBuffer, meta.logOffset) : null;

--- a/src/galactic/utility/__tests__/getDataShape.test.ts
+++ b/src/galactic/utility/__tests__/getDataShape.test.ts
@@ -1,30 +1,30 @@
 import { expect, test } from 'vitest';
 
 import { getDataShape } from '../getDataShape.ts';
-import { FlagParameters } from '../headerUtils.ts';
+import { parseFlagParameters } from '../headerUtils.ts';
 
 test('Data shape', () => {
-  const y = new FlagParameters(0b00000000);
+  const y = parseFlagParameters(0b00000000);
 
   expect(getDataShape(y)).toBe('Y');
 
-  const exception = new FlagParameters(0b11000000);
+  const exception = parseFlagParameters(0b11000000);
 
   expect(getDataShape(exception)).toBe('exception');
 
-  const yy = new FlagParameters(0b00000100);
+  const yy = parseFlagParameters(0b00000100);
 
   expect(getDataShape(yy)).toBe('YY');
 
-  const xy = new FlagParameters(0b10000000);
+  const xy = parseFlagParameters(0b10000000);
 
   expect(getDataShape(xy)).toBe('XY');
 
-  const xyy = new FlagParameters(0b10000100);
+  const xyy = parseFlagParameters(0b10000100);
 
   expect(getDataShape(xyy)).toBe('XYY');
 
-  const xyxy = new FlagParameters(0b11000100);
+  const xyxy = parseFlagParameters(0b11000100);
 
   expect(getDataShape(xyxy)).toBe('XYXY');
 });

--- a/src/galactic/utility/__tests__/headerUtils.test.ts
+++ b/src/galactic/utility/__tests__/headerUtils.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'vitest';
 
-import { FlagParameters, longToDate } from '../headerUtils.ts';
+import { longToDate, parseFlagParameters } from '../headerUtils.ts';
 
 test('Flag parameters', () => {
-  const instance = new FlagParameters(255);
+  const instance = parseFlagParameters(255);
 
   expect(instance.y16BitPrecision).toBe(true);
   expect(instance.useExperimentExtension).toBe(true);

--- a/src/galactic/utility/guessSpectraType.ts
+++ b/src/galactic/utility/guessSpectraType.ts
@@ -1,5 +1,4 @@
 import type { Header } from '../fileHeader.ts';
-import { TheNewHeader } from '../fileHeader.ts';
 
 import { getDataShape } from './getDataShape.ts';
 
@@ -18,7 +17,7 @@ export function guessSpectraType(meta: Header): SpectraType {
   //function tested with the `fileHeader.test.ts`
   // for the new file header they define a "experiment type"
   if (
-    meta instanceof TheNewHeader && // "General SPC" does not give any information
+    meta.kind === 'new' && // "General SPC" does not give any information
     !meta.experimentType.startsWith('General SPC')
   ) {
     const id = meta.experimentType.split(' ', 1)[0];

--- a/src/galactic/utility/headerUtils.ts
+++ b/src/galactic/utility/headerUtils.ts
@@ -1,27 +1,39 @@
+/** The parameters encoded in each bit of the main header flag. */
+export interface FlagParameters {
+  /** Y values are 16 bits instead of 32. */
+  y16BitPrecision: boolean;
+  /** Enable experiment mode. */
+  useExperimentExtension: boolean;
+  /** Multiple spectra (multifile). */
+  multiFile: boolean;
+  /** Z values in random order if multiFile. */
+  zValuesRandom: boolean;
+  /** Z values ordered but unevenly spaced if multiFile. */
+  zValuesUneven: boolean;
+  /** Custom labels. */
+  customAxisLabels: boolean;
+  /** One X array per subfile, for discontinuous curves. */
+  xyxy: boolean;
+  /** Non-evenly spaced X, X before Y. */
+  xy: boolean;
+}
+
 /**
- * Gets the parameter in each bit of the flag
- * @param  flag - First byte of the main header.
- * @returns  The parameters.
+ * Gets the parameter in each bit of the flag.
+ * @param flag - First byte of the main header.
+ * @returns The parameters.
  */
-export class FlagParameters {
-  public y16BitPrecision: boolean;
-  public useExperimentExtension: boolean;
-  public multiFile: boolean;
-  public zValuesRandom: boolean;
-  public zValuesUneven: boolean;
-  public customAxisLabels: boolean;
-  public xyxy: boolean;
-  public xy: boolean;
-  constructor(flag: number) {
-    this.y16BitPrecision = (flag & 1) !== 0; //Y values are 16 bits instead of 32
-    this.useExperimentExtension = (flag & 2) !== 0; //Enable experiment mode
-    this.multiFile = (flag & 4) !== 0; //Multiple spectra (multifile)
-    this.zValuesRandom = (flag & 8) !== 0; //Z values in random order if multiFile
-    this.zValuesUneven = (flag & 16) !== 0; //Z values ordered but unevenly spaced if multi
-    this.customAxisLabels = (flag & 32) !== 0; //Custom labels
-    this.xyxy = (flag & 64) !== 0; //One X array per subfile, for discontinuous curves
-    this.xy = (flag & 128) !== 0; // Non-evenly spaced X, X before Y
-  }
+export function parseFlagParameters(flag: number): FlagParameters {
+  return {
+    y16BitPrecision: (flag & 1) !== 0,
+    useExperimentExtension: (flag & 2) !== 0,
+    multiFile: (flag & 4) !== 0,
+    zValuesRandom: (flag & 8) !== 0,
+    zValuesUneven: (flag & 16) !== 0,
+    customAxisLabels: (flag & 32) !== 0,
+    xyxy: (flag & 64) !== 0,
+    xy: (flag & 128) !== 0,
+  };
 }
 
 /**


### PR DESCRIPTION
The galactic header/subheader classes had no methods — they were parse functions written as constructors. This converts `FlagParameters`, `SubFlagParameters`, `SubHeader`, `TheOldHeader` and `TheNewHeader` to interfaces + parse functions, and discriminates the `Header` union with a `kind` field instead of `instanceof`.

Parsing behavior is unchanged (byte-read order preserved); `result.meta` now additionally carries a `kind: 'old' | 'new'` field.

closes: https://github.com/cheminfo/spc-parser/issues/30

🤖 Generated with [Claude Code](https://claude.com/claude-code)